### PR TITLE
Add expiration date to cache

### DIFF
--- a/Pellicola/Classes/PellicolaCache.swift
+++ b/Pellicola/Classes/PellicolaCache.swift
@@ -10,7 +10,12 @@ import Foundation
 @objcMembers
 public final class PellicolaCache: NSObject {
     private let fileHandler = PellicolaFileHandler()
-    public var expirationDate = Date()
+    private let expirationDate: Date
+    
+    public init(expirationDate: Date) {
+        self.expirationDate = expirationDate
+        super.init()
+    }
     
     public func clear() {
         DispatchQueue.global(qos: .utility).async {

--- a/Pellicola/Classes/PellicolaCache.swift
+++ b/Pellicola/Classes/PellicolaCache.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 
+@objcMembers
 public final class PellicolaCache: NSObject {
     private let fileHandler = PellicolaFileHandler()
+    public var expirationDate = Date()
     
-    @objc public func clear() {
+    public func clear() {
         DispatchQueue.global(qos: .utility).async {
-            self.fileHandler.deleteAllImages()
+            self.fileHandler.deleteImages(olderThan: self.expirationDate)
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ class ViewController: UIViewController {
         
         pellicolaPresenter = PellicolaPresenter(style: DefaultPellicolaStyle())
         
-        pellicolaPresenter.didSelectImages = { images in
+        pellicolaPresenter.didStartProcessingImages = {
+            print("Processing images")
+        }
+        
+        pellicolaPresenter.didFinishProcessingImages = { images in
             print("User selected \(images.count) images")
         }
         


### PR DESCRIPTION
This PR adds `expirationDate` to cache in order to specify storage time of temporary image files.